### PR TITLE
Require Underscore.js if not already available

### DIFF
--- a/lib/lemonad.js
+++ b/lib/lemonad.js
@@ -9,7 +9,7 @@
   // ------------
 
   // Require Underscore.js if not already available.
-  var _ = this['_'] || require('underscore');
+  var _ = this._ || require('underscore');
 
   // Setup
   // -----


### PR DESCRIPTION
Maybe I'm missing something obvious, but it seems like the current version of Lemonad will not work in Node, since it is assumed that `_` is available on the global object.
