### PR TITLE
Allow L.snapshot to take non-existy values

### DIFF
--- a/lib/lemonad.js
+++ b/lib/lemonad.js
@@ -98,7 +98,7 @@
   // or clones the object outright if not.
 
   L.snapshot = function(thing) {
-    if (L.existy(thing.snapshot))
+    if (L.existy(thing) && L.existy(thing.snapshot))
       return thing.snapshot();
     else
       return theClonusHorror(thing);


### PR DESCRIPTION
`null` and `undefined` do not allow property reads (e.g. `null.foo`). So
without the existy check `L.snapshot(null)` and `L.snapshot(undefined)`
throw TypeErrors.
