### PR TITLE
Added Aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ currently available functions:
   'lift',
   'lt',
   'meth',
+  'invoker',
   'walterWhite',
   'mix',
   'partial1',


### PR DESCRIPTION
I was reading the source and noticed a hilarious alias for L.meth() that should be added to the README.md
