### PR TITLE
Strictly-Typed Function Constructor

### DIFF
--- a/lib/lemonad.js
+++ b/lib/lemonad.js
@@ -916,7 +916,7 @@
 
       return fun(arg);
     };
-  };  
+  };
 
   function getType(type) {
     if( typeof type == 'function' ) {
@@ -980,8 +980,8 @@
     return L.checker(msg, checker.fun);
   }
 
-  L.typed = function(fun/*, checkers */) {
-    var checkers = L.toArray(arguments).slice(1).map(argTypeChecker);
+  L.typed = function(fun/*, types */) {
+    var types = L.toArray(arguments).slice(1).map(argTypeChecker);
 
     return function(/* args */) {
       var args = L.toArray(arguments);
@@ -989,7 +989,7 @@
         var arg = args[0];
         args = args.slice(1);
         return isValid(arg) ? [] : [isValid.message];
-      }, checkers);
+      }, types);
 
       if (!L.isEmpty(errors))
         throw new Error(errors.join(", "));


### PR DESCRIPTION
This is a basic version of something we discussed on Twitter, intended as one solution to type checking. The basic usage is of the following form.

``` javascript
var strictFun = L.typed(fun, String, [Number]);
strictFun("", [1]); 
// => fun("", [1]);
strictFun(0, [1]);
// => Error: Expected argument at index 0 to be of type String.
```

Currently, it simply supports strings, numbers, and dictionaries or arrays of the supported types. Of course, checking of function types will be our main obstacle down the road; however, a simple extension of `L.typed` to include return type and its checking would allow `L.typed` constructed functions to be composed in a type-checked manner.
